### PR TITLE
use terminal.css for styling and centre content

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,39 @@
 <head>
     <meta charset="UTF-8">
     <title>Limine</title>
+
+    <link rel="stylesheet" href="https://unpkg.com/terminal.css@0.7.2/dist/terminal.min.css" />
+    <style>
+        :root {
+            --global-font-size: 15px;
+            --global-line-height: 1.4em;
+            --global-space: 10px;
+            --font-stack: Menlo, Monaco, Lucida Console, Liberation Mono,
+              DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace,
+              serif;
+            --mono-font-stack: Menlo, Monaco, Lucida Console, Liberation Mono,
+              DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace,
+              serif;
+            --background-color: #222225;
+            --page-width: 60em;
+            --font-color: #e8e9ed;
+            --invert-font-color: #222225;
+            --secondary-color: #a3abba;
+            --tertiary-color: #a3abba;
+            --primary-color: #62c4ff;
+            --error-color: #ff3c74;
+            --progress-bar-background: #3f3f44;
+            --progress-bar-fill: #62c4ff;
+            --code-bg-color: #3f3f44;
+            --input-style: solid;
+            --display-h1-decoration: none;
+        }
+
+        body {
+            max-width: 80ch;
+            margin: auto;
+        }
+    </style>
 </head>
 <body>
     <center>


### PR DESCRIPTION
centring content makes it easier to read, and using terminal.css means no need to maintain a stylesheet.